### PR TITLE
feat(frontend): Tag buttons for preferences

### DIFF
--- a/frontend/src/api/preferences.ts
+++ b/frontend/src/api/preferences.ts
@@ -51,9 +51,8 @@ export interface PreferencesUpdatePayload {
  * GET /api/auth/preferences/
  */
 export async function getPreferences(): Promise<UserPreferencesResponse> {
-    const { data } = await api.get<UserPreferencesResponse>(
-        "/auth/preferences/"
-    );
+    const { data } =
+        await api.get<UserPreferencesResponse>("/auth/preferences/");
     return data;
 }
 
@@ -62,11 +61,11 @@ export async function getPreferences(): Promise<UserPreferencesResponse> {
  * PATCH /api/auth/preferences/
  */
 export async function updatePreferences(
-    payload: PreferencesUpdatePayload
+    payload: PreferencesUpdatePayload,
 ): Promise<UserPreferencesResponse> {
     const { data } = await api.patch<UserPreferencesResponse>(
         "/auth/preferences/",
-        payload
+        payload,
     );
     return data;
 }

--- a/frontend/src/components/create-card/CardFrontsideField.tsx
+++ b/frontend/src/components/create-card/CardFrontsideField.tsx
@@ -1,8 +1,12 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState } from "react";
 import { CornerDownLeft } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { SubtleButton } from "@/components/create-card/SubtleButton";
+import TagButton from "@/components/create-card/TagButton";
+import { getPreferences, updatePreferences } from "@/api/preferences.ts";
+import type { Preferences } from "@/api/preferences.ts";
+import { toast } from "sonner";
 
 interface CardFrontsideFieldProps {
     value: string;
@@ -10,7 +14,51 @@ interface CardFrontsideFieldProps {
     onSubmit: () => void;
     isGenerating: boolean;
     completionsEnabled: boolean;
+    rapidModeEnabled: boolean;
 }
+
+interface Tags {
+    verbose: boolean;
+    concise: boolean;
+    example: boolean;
+    mnemonic: boolean;
+    paragraph: boolean;
+    analogy: boolean;
+    step_by_step: boolean;
+    german: boolean;
+}
+
+const prefsToTags = (prefs: Preferences): Tags => {
+    return {
+        verbose: prefs.verbosity === "detailed",
+        concise: prefs.verbosity === "concise",
+        example: prefs.include_examples,
+        mnemonic: prefs.include_mnemonic,
+        paragraph: prefs.structure === "paragraph",
+        analogy: prefs.include_analogies,
+        step_by_step: prefs.step_by_step,
+        german: prefs.language == "de",
+    };
+};
+
+/* Only returns prefs assoiated with tags, i.e. Preferences object will miss some keys
+ */
+const tagsToPrefsPatch = (tags: Tags): Partial<Preferences> => {
+    return {
+        verbosity: tags.verbose
+            ? "detailed"
+            : tags.concise
+              ? "concise"
+              : "balanced",
+        structure: tags.paragraph ? "paragraph" : "bullets",
+        include_examples: tags.example,
+        examples_per_answer: tags.example ? 1 : 0,
+        include_analogies: tags.analogy,
+        step_by_step: tags.step_by_step,
+        include_mnemonic: tags.mnemonic,
+        language: tags.german ? "de" : "en",
+    };
+};
 
 const CardFrontsideField = ({
     value,
@@ -18,9 +66,72 @@ const CardFrontsideField = ({
     onSubmit,
     isGenerating = false,
     completionsEnabled,
+    rapidModeEnabled,
 }: CardFrontsideFieldProps) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const wasFocusedRef = useRef(false);
+
+    const [tagsLoading, setTagsLoading] = useState<boolean>(true);
+    const [tags, setTags] = useState<Tags>({
+        verbose: false,
+        concise: false,
+        example: false,
+        mnemonic: false,
+        paragraph: false,
+        analogy: false,
+        step_by_step: false,
+        german: false,
+    });
+
+    const updateServerPreferences = async (nextTags: Tags): Promise<void> => {
+        await updatePreferences({
+            preferences: tagsToPrefsPatch(nextTags),
+        });
+    };
+
+    const handleToggleTag = async (tag_name: keyof Tags) => {
+        const prevTags = tags;
+
+        const newTags = { ...tags, [tag_name]: !tags[tag_name] };
+        // mutually exclusive tags
+        if (tag_name === "concise" && !tags.concise) newTags.verbose = false;
+        if (tag_name === "verbose" && !tags.verbose) newTags.concise = false;
+
+        // Optimistically update UI
+        setTags(newTags);
+
+        // Try to update server, revert on failure
+        try {
+            await updateServerPreferences(newTags);
+        } catch {
+            toast.error("Preferences could not be updated.");
+            setTags(prevTags);
+        }
+    };
+
+    // get preferences once on load
+    useEffect(() => {
+        // just so that toast doesn't show twice in strict mode
+        let cancelled = false;
+
+        const fetchTagsFromServer = async () => {
+            setTagsLoading(true);
+            try {
+                const response = await getPreferences();
+                if (cancelled) return;
+                setTags(prefsToTags(response.preferences));
+                setTagsLoading(false);
+            } catch {
+                if (cancelled) return;
+                toast.error("Could not fetch tags from server.");
+            }
+        };
+
+        fetchTagsFromServer();
+        return () => {
+            cancelled = true;
+        };
+    }, []); // might need something else in the dependency array
 
     useEffect(() => {
         if (!isGenerating && wasFocusedRef.current) {
@@ -54,19 +165,34 @@ const CardFrontsideField = ({
                     disabled={isGenerating}
                 />
                 <div
-                    className={`flex justify-end -mt-2 -mb-6 ${completionsEnabled ? "" : "invisible"}`}
+                    className={`flex justify-between -mt-2 -mb-4 items-start ${completionsEnabled ? "" : "invisible"}`}
                 >
-                    <SubtleButton
-                        icon={CornerDownLeft}
-                        text="Generate backside"
-                        onClick={onSubmit}
-                        onFocus={() => (wasFocusedRef.current = true)}
-                        onBlur={() => {
-                            if (!isGenerating) {
-                                wasFocusedRef.current = false;
-                            }
-                        }}
-                    />
+                    <div
+                        className={`flex gap-1 ${rapidModeEnabled ? "invisible" : ""}`}
+                    >
+                        {(Object.keys(tags) as (keyof Tags)[]).map((name) => (
+                            <TagButton
+                                key={name}
+                                text={name.replace(/_/g, "-")}
+                                enabled={tags[name]}
+                                disabled={tagsLoading}
+                                onClick={() => handleToggleTag(name)}
+                            />
+                        ))}
+                    </div>
+                    <div className="flex gap-1">
+                        <SubtleButton
+                            icon={CornerDownLeft}
+                            text="Generate backside"
+                            onClick={onSubmit}
+                            onFocus={() => (wasFocusedRef.current = true)}
+                            onBlur={() => {
+                                if (!isGenerating) {
+                                    wasFocusedRef.current = false;
+                                }
+                            }}
+                        />
+                    </div>
                 </div>
             </Field>
         </FieldGroup>

--- a/frontend/src/components/create-card/TagButton.tsx
+++ b/frontend/src/components/create-card/TagButton.tsx
@@ -1,0 +1,43 @@
+interface TagButtonProps {
+    text: string;
+    onClick?: () => void;
+    onFocus?: () => void;
+    onBlur?: () => void;
+    enabled: boolean;
+    disabled?: boolean;
+    className?: string;
+}
+
+const TagButton = ({
+    text,
+    onClick,
+    onFocus,
+    onBlur,
+    enabled,
+    disabled = false,
+    className = "",
+}: TagButtonProps) => {
+    const stateBasedStyle = enabled ? "bg-gray-800" : "bg-gray-300";
+    const hoverStyle = disabled
+        ? ""
+        : enabled
+          ? "hover:bg-gray-700"
+          : "hover:bg-gray-400";
+    const disabledStyle = disabled
+        ? "opacity-50 cursor-not-allowed"
+        : "cursor-pointer";
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={`flex items-center gap-1.5 px-2 py-[0.05rem] text-xs text-white rounded-full transition-colors ${stateBasedStyle} ${hoverStyle} ${disabledStyle} ${className}`}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            disabled={disabled}
+        >
+            {text}
+        </button>
+    );
+};
+
+export default TagButton;

--- a/frontend/src/pages/Deck/CreateCardPage.tsx
+++ b/frontend/src/pages/Deck/CreateCardPage.tsx
@@ -288,6 +288,7 @@ const CreateCardPage = () => {
                 }
                 isGenerating={isGenerating}
                 completionsEnabled={completionsEnabled}
+                rapidModeEnabled={rapidModeEnabled}
             />
             <CardBacksideField
                 ref={backsideEditorRef}


### PR DESCRIPTION
Added tag buttons under the "front of card field" which quickly control user preferences in a conventient fashion.

Also handles edge cases, e.g. not being able to fetch the tag status from server or not being able to update a tag status because of a server error.